### PR TITLE
[BUGFIX] Clean up LSPHP

### DIFF
--- a/ols1clk.sh
+++ b/ols1clk.sh
@@ -783,6 +783,7 @@ function install_ols
         echo "$STATUS on Debian/Ubuntu"
         install_ols_debian $STATUS
     fi
+    killall -9 lsphp
 }
 
 
@@ -1020,6 +1021,7 @@ function uninstall
     if [ "x$OLSINSTALLED" = "x1" ] ; then
         echoY "Uninstalling ..."
         $SERVER_ROOT/bin/lswsctrl stop
+        killall -9 lsphp
         if [ "x$OSNAME" = "xcentos" ] ; then
             echo "Uninstall on Centos"
             uninstall_ols_centos


### PR DESCRIPTION
During uninstall, LSPHP is not cleaned up.

When installing OLS, the install package will run PHP. This leaves a running lsphp process. lsphp7x-json is installed afterwards, meaning the active lsphp process does not include JSON. Later, when testing the WordPress admin page, the test will fail because the active lsphp process does not include JSON.